### PR TITLE
Switch runtime buildpack to a supported Python version

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.2
+python-3.6.4


### PR DESCRIPTION
The file `runtime.txt` instructs CloudFoundry to use a particular version of [buildpack](https://console.bluemix.net/docs/runtimes/python/index.html#python_runtime).
The deploy logs for `cf push` list the available runtimes as follows (different from docs):
```
-----> Python Buildpack version 1.6.11
       **WARNING** buildpack version changed from 1.5.22 to 1.6.11
-----> Supplying Python
       **ERROR** Could not install python: no match found for 3.6.2 in
[2.7.13 2.7.14 3.3.6 3.3.7 3.4.7 3.4.8 3.5.4 3.5.5 3.6.3 3.6.4]
```