### PR TITLE
Add data persistence

### DIFF
--- a/apps/api/endpoints/events.py
+++ b/apps/api/endpoints/events.py
@@ -1,20 +1,31 @@
 from flask import request
 from flask_restplus import Resource, fields
 from api.restplus import api
+from database.clients import get_db
+from cloudant.result import Result
 
 ns = api.namespace('events', description='Operations related to scheduled events')
 an_event = api.model('Event', {'title' : fields.String('The name of the event as promoted publically')})
 
 events = []
-beggs = {'title': 'John Beggs Memorial'}
-events.append(beggs)
 
 @ns.route('/')
-class Event(Resource):
+class Events(Resource):
 	def get(self):
-		return events
+		db = get_db('events')
+		print("listing documents in events database".format(db.all_docs()))
+		all_events = Result(db.all_docs, include_docs=True)
+		return [event for event in all_events]
+		#return events
 
 	@api.expect(an_event)
 	def post(self):
+		#doc = db_client.create_document(api.payload)
 		events.append(api.payload)
-		return api.payload, 201
+		doc = api.payload
+		return doc, 201
+
+ns.route('/<int:id>')
+@api.response(404, 'Category not found.')
+class Event(Resource):
+	pass

--- a/apps/app.py
+++ b/apps/app.py
@@ -1,39 +1,15 @@
-from cloudant import Cloudant
 from flask import Flask, render_template, request, jsonify, Blueprint
 from flask_restplus import Resource, Api
+from database.clients import init_db, shutdown_db
 from api.restplus import api
 from api.endpoints.events import ns as events_namespace
 import atexit
 import os
 import json
 
-def init_db():
-	db_name = 'events'
-	db = None
-	client = None
-	if 'VCAP_SERVICES' in os.environ:
-		vcap = json.loads(os.getenv('VCAP_SERVICES'))
-		print('Found VCAP_SERVICES')
-		if 'cloudantNoSQLDB' in vcap:
-			creds = vcap['cloudantNoSQLDB'][0]['credentials']
-			user = creds['username']
-			password = creds['password']
-			url = 'https://' + creds['host']
-			client = Cloudant(user, password, url=url, connect=True)
-			db = client.create_database(db_name, throw_on_exists=False)
-	elif os.path.isfile('vcap-local.json'):
-		with open('vcap-local.json') as f:
-			vcap = json.load(f)
-			print('Found local VCAP_SERVICES')
-			creds = vcap['services']['cloudantNoSQLDB'][0]['credentials']
-			user = creds['username']
-			password = creds['password']
-			url = 'https://' + creds['host']
-			client = Cloudant(user, password, url=url, connect=True)
-			db = client.create_database(db_name, throw_on_exists=False)
-	return client
-
 def init_app(flask_app):
+	app.config['DATABASE'] = 'events'
+
 	blueprint = Blueprint('api', __name__, url_prefix='/api')
 	api.init_app(blueprint)
 	api.add_namespace(events_namespace)
@@ -41,13 +17,13 @@ def init_app(flask_app):
 
 @atexit.register
 def shutdown():
-	if client:
-		client.disconnect()
-
+	with app.app_context():
+		shutdown_db()
 
 app = Flask(__name__, static_url_path='')
-client = init_db()
 init_app(app)
+with app.app_context():
+	init_db(app.config)
 # On IBM Cloud Cloud Foundry, get the port number from the environment variable PORT
 # When running this app on the local machine, default the port to 8000
 port = int(os.getenv('PORT', 8000))

--- a/apps/database/clients.py
+++ b/apps/database/clients.py
@@ -1,0 +1,58 @@
+'''This module encapsulates database functions
+and can be used to obtain a database client for
+any of the application's databases'''
+import os
+import json
+from cloudant import Cloudant
+from flask import g, app
+
+def init_db(config):
+	if not 'DATABASE' in config:
+		print("Error: I don't know which database to use!")
+	get_db(config['DATABASE'])
+
+def get_db(db_name='events'):
+	'''Return a CloudantDatabase object'''
+	if 'db_client' not in g:
+		g.db_client = connect_db(db_name)
+	if db_name not in g.db_client:
+		g.db_client = connect_db(db_name, client=client)
+	return g.db_client[db_name]
+
+def shutdown_db():
+	db_client = g.pop('db_client', None)
+	if db_client is not None:
+		db_client.disconnect()
+
+def connect_db(db_name, db_client=None):
+	'''Connect a database client to the server configured in VCAP_SERVICES
+	and open the named database.
+	If the database does not exist it will be created.
+	Returns the database client.'''
+	db = None
+	client = db_client
+	if 'VCAP_SERVICES' in os.environ:
+		vcap = json.loads(os.getenv('VCAP_SERVICES'))
+		print('Found VCAP_SERVICES')
+		if 'cloudantNoSQLDB' in vcap:
+			creds = vcap['cloudantNoSQLDB'][0]['credentials']
+			user = creds['username']
+			password = creds['password']
+			url = 'https://' + creds['host']
+			client = Cloudant(user, password, url=url, connect=True)
+			db = client.create_database(db_name, throw_on_exists=False)
+	elif os.path.isfile('apps/vcap-local.json'):
+		with open('apps/vcap-local.json') as f:
+			vcap = json.load(f)
+			print('Found local VCAP_SERVICES')
+			creds = vcap['services']['cloudantNoSQLDB'][0]['credentials']
+			user = creds['username']
+			password = creds['password']
+			url = 'https://' + creds['host']
+			client = Cloudant(user, password, url=url, connect=True)
+			db = client.create_database(db_name, throw_on_exists=False)
+	else:
+		print('No VCAP_SERVICES found')
+	if db is not None:
+		print('Connected to {0} database'.format(db_name))
+	return client

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -5,6 +5,7 @@ from context import app # check sys.path if this fails
 @pytest.fixture
 def client():
 	app.app.config['TESTING'] = True
+	app.app.config['DATABASE'] = 'test_events'
 	client = app.app.test_client()
 
 	yield client
@@ -19,3 +20,17 @@ def test_get_events(client):
 	rv = client.get('/api/events/')
 	json_resp = rv.get_json()
 	assert json_resp is not None
+	assert verify_list(json_resp)
+
+def test_post_events(client):
+	'''Test event creation api'''
+	event = {'title': 'The John Beggs'}
+
+	rv = client.post('/api/events/', json=event)
+	json_resp = rv.get_json()
+	assert json_resp is not None
+	assert json_resp['title'] == 'The John Beggs'
+
+def verify_list(obj):
+	'''Return True iff obj is a list-like object'''
+	return 'index' in dir(obj) and 'append' in dir(obj)


### PR DESCRIPTION
Connect to a remote [Cloudant](http://python-cloudant.readthedocs.io/en/latest/getting_started.html#creating-a-document) database
`GET /api/events/` results are retrieved from the db
Other APIs do not use the db yet.