### PR TITLE
Prepare to Persist

### DIFF
--- a/apps/api/endpoints/events.py
+++ b/apps/api/endpoints/events.py
@@ -23,6 +23,7 @@ class Events(Resource):
 		#doc = db_client.create_document(api.payload)
 		events.append(api.payload)
 		doc = api.payload
+		doc['id'] = len(events)
 		return doc, 201
 
 ns.route('/<int:id>')

--- a/drivetrain/keys/prod-deploy-key
+++ b/drivetrain/keys/prod-deploy-key
@@ -1,0 +1,1 @@
+GobknHOWWIerORmsK-6LIjikhj_vTNKM2fO5w2_sBB5M

--- a/drivetrain/stages/production/jobs/deploy.sh
+++ b/drivetrain/stages/production/jobs/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # deploy a cloud foundry app
 
-cf delete -r -f "${CF_APP}"
-cf push "${CF_APP}"
+#cf delete -r -f "${CF_APP}"
+cf push -n "${CF_APP}" "${CF_APP}"
 # View logs
 # cf logs "${CF_APP}" --recent

--- a/drivetrain/stages/staging/jobs/deploy.sh
+++ b/drivetrain/stages/staging/jobs/deploy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cf push -n "staging-${CF_APP}" "${CF_APP}"
+# View logs
+# cf logs "${CF_APP}" --recent

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -30,6 +30,7 @@ def test_post_events(client):
 	json_resp = rv.get_json()
 	assert json_resp is not None
 	assert json_resp['title'] == 'The John Beggs'
+	assert 'id' in json_resp
 
 def verify_list(obj):
 	'''Return True iff obj is a list-like object'''


### PR DESCRIPTION
Partial implementation of data persistence.
This change set lays the groundwork for data persistence through Cloudant.
The application remains transient until other functionality is implemented first.