### PR TITLE
Event apis

### DIFF
--- a/apps/api/endpoints/events.py
+++ b/apps/api/endpoints/events.py
@@ -26,7 +26,9 @@ class Events(Resource):
 		doc['id'] = len(events)
 		return doc, 201
 
-ns.route('/<int:id>')
-@api.response(404, 'Category not found.')
+@ns.route('/<int:id>')
+@api.response(404, 'Event not found')
 class Event(Resource):
-	pass
+	def get(self, id):
+		"""Returns details of an event"""
+		return events[id-1]

--- a/apps/api/endpoints/events.py
+++ b/apps/api/endpoints/events.py
@@ -23,7 +23,7 @@ class Events(Resource):
 		#return events
 
 	@api.expect(an_event)
-	@api.response(201, 'Event created successfully')
+	@api.response(201, 'Event created')
 	def post(self):
 		#doc = db_client.create_document(api.payload)
 		events.append(api.payload)
@@ -37,3 +37,10 @@ class Event(Resource):
 	def get(self, id):
 		"""Returns details of an event"""
 		return events[id-1]
+
+	@api.expect(an_event)
+	@api.response(204, 'Event updated')
+	def put(self, id):
+		"""Updates attributes of an existing event"""
+		events[id-1] = api.payload
+		return None, 204

--- a/apps/api/endpoints/events.py
+++ b/apps/api/endpoints/events.py
@@ -36,17 +36,26 @@ class Events(Resource):
 class Event(Resource):
 	def get(self, id):
 		"""Returns details of an event"""
-		return events[id-1]
+		if 0 < id <= len(events):
+			return events[id-1], 200
+		else:
+			return None, 404
 
 	@api.expect(an_event)
 	@api.response(204, 'Event updated')
 	def put(self, id):
 		"""Updates attributes of an existing event"""
-		events[id-1] = api.payload
-		return None, 204
+		if 0 < id <= len(events):
+			events[id-1] = api.payload
+			return None, 204
+		else:
+			return None, 404
 
 	@api.response(204, 'Event deleted')
 	def delete(self, id):
 		"""Deletes an existing event"""
-		del events[id-1]
-		return None, 204
+		if 0 < id <= len(events):
+			del events[id-1]
+			return None, 204
+		else:
+			return None, 404

--- a/apps/api/endpoints/events.py
+++ b/apps/api/endpoints/events.py
@@ -44,3 +44,9 @@ class Event(Resource):
 		"""Updates attributes of an existing event"""
 		events[id-1] = api.payload
 		return None, 204
+
+	@api.response(204, 'Event deleted')
+	def delete(self, id):
+		"""Deletes an existing event"""
+		del events[id-1]
+		return None, 204

--- a/apps/api/endpoints/events.py
+++ b/apps/api/endpoints/events.py
@@ -5,12 +5,16 @@ from database.clients import get_db
 from cloudant.result import Result
 
 ns = api.namespace('events', description='Operations related to scheduled events')
-an_event = api.model('Event', {'title' : fields.String('The name of the event as promoted publically')})
+an_event = api.model('Event', {
+	'id': fields.Integer(description='The unique identifier of an event', readonly=True),
+	'title' : fields.String(required=True, description='The name of the event as promoted publically', example='The John Beggs Memorial')
+	})
 
 events = []
 
 @ns.route('/')
 class Events(Resource):
+	@api.response(200, 'Events found')
 	def get(self):
 		db = get_db('events')
 		print("listing documents in events database".format(db.all_docs()))
@@ -19,6 +23,7 @@ class Events(Resource):
 		#return events
 
 	@api.expect(an_event)
+	@api.response(201, 'Event created successfully')
 	def post(self):
 		#doc = db_client.create_document(api.payload)
 		events.append(api.payload)

--- a/apps/api/endpoints/events.py
+++ b/apps/api/endpoints/events.py
@@ -16,11 +16,11 @@ events = []
 class Events(Resource):
 	@api.response(200, 'Events found')
 	def get(self):
-		db = get_db('events')
-		print("listing documents in events database".format(db.all_docs()))
-		all_events = Result(db.all_docs, include_docs=True)
-		return [event for event in all_events]
-		#return events
+		#db = get_db('events')
+		#print("listing documents in events database".format(db.all_docs()))
+		#all_events = Result(db.all_docs, include_docs=True)
+		#return [event for event in all_events]
+		return events
 
 	@api.expect(an_event)
 	@api.response(201, 'Event created')

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -49,6 +49,14 @@ def test_get_events(client):
 	assert events_result is not None
 	assert_list(events_result)
 
+def test_get_events_not_empty(client):
+	"""Test GET /events API for events listing when events do exist"""
+	event_fixture = _post_event_fixture(client, 'GET Events Test')
+
+	rv = client.get('/api/events/')
+	events_result = rv.get_json()
+	assert events_result # assert that list is not None or empty
+
 def test_post_events(client):
 	'''Test POST /events API for event creation'''
 	event_fixture = {'title': 'The John Beggs'}
@@ -57,7 +65,6 @@ def test_post_events(client):
 	event_result = rv.get_json()
 	assert event_result is not None
 	assert event_result['title'] == event_fixture['title']
-	assert 'id' in event_result
 
 def test_get_event(client):
 	"""Test GET /events/{id} API"""

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -35,3 +35,15 @@ def test_post_events(client):
 def verify_list(obj):
 	'''Return True iff obj is a list-like object'''
 	return 'index' in dir(obj) and 'append' in dir(obj)
+
+def test_get_event(client):
+	"""Test GET /event API"""
+	event = {'title': 'GET Event Test'}
+	post_rv = client.post('/api/events/', json=event)
+	event_id = post_rv.get_json()['id']
+
+	get_rv = client.get('/api/events/{id}'.format(id=event_id))
+	json_response = get_rv.get_json()
+	assert json_response is not None
+	assert 'id' in json_response and json_response['id'] == event_id
+	assert 'title' in json_response and json_response['title'] == event['title']

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -57,4 +57,12 @@ def test_get_event(client):
 	assert 'title' in event_result and event_result['title'] == event_fixture['title']
 
 def test_put_event(client):
-	"""Test PUT /events/{id} API"""
+	"""Test PUT /events/{id} API for event modification"""
+	event_fixture = _post_event_fixture(client, 'PUT Event Test')
+	event_fixture['title'] = "{original} modified".format(original=event_fixture['title'])
+
+	put_rv = client.put('/api/events/{id}'.format(id=event_fixture['id']), json=event_fixture)
+	event_result = put_rv.get_json()
+	assert event_result is not None
+	assert 'id' in event_result and event_result['id'] == event_fixture['id']
+	assert 'title' in event_result and event_result['title'] == event_fixture['title']

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -18,6 +18,13 @@ def _post_event_fixture(client, title):
 	post_rv = client.post('/api/events/', json=event)
 	return post_rv.get_json()
 
+def _get_event_fixture(client, id):
+	'''Return an event for use in test cases
+	Assumes that the `test_get_event` testcase passes
+	and that an event with {id} has already been created'''
+	get_rv = client.get('/api/events/{id}'.format(id=id))
+	return get_rv.get_json()
+
 # test assertion functions
 def assert_list(obj):
 	'''Return True iff obj is a list-like object'''
@@ -62,7 +69,6 @@ def test_put_event(client):
 	event_fixture['title'] = "{original} modified".format(original=event_fixture['title'])
 
 	put_rv = client.put('/api/events/{id}'.format(id=event_fixture['id']), json=event_fixture)
-	event_result = put_rv.get_json()
-	assert event_result is not None
-	assert 'id' in event_result and event_result['id'] == event_fixture['id']
+	assert put_rv.status_code == 204
+	event_result = _get_event_fixture(client, event_fixture['id'])
 	assert 'title' in event_result and event_result['title'] == event_fixture['title']

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -21,9 +21,13 @@ def _post_event_fixture(client, title):
 def _get_event_fixture(client, id):
 	'''Return an event for use in test cases
 	Assumes that the `test_get_event` testcase passes
-	and that an event with {id} has already been created'''
+	and that an event with {id} has already been created.
+	Returns None (does not raise an error) if event not found'''
 	get_rv = client.get('/api/events/{id}'.format(id=id))
-	return get_rv.get_json()
+	if get_rv.status_code == 404:
+		return None
+	else:
+		return get_rv.get_json()
 
 # test assertion functions
 def assert_list(obj):
@@ -72,3 +76,12 @@ def test_put_event(client):
 	assert put_rv.status_code == 204
 	event_result = _get_event_fixture(client, event_fixture['id'])
 	assert 'title' in event_result and event_result['title'] == event_fixture['title']
+
+def test_delete_event(client):
+	"""Test DELETE /events/{id} API for event deletion"""
+	event_fixture = _post_event_fixture(client, 'DELETE Event Test')
+
+	delete_rv = client.delete('/api/events/{id}'.format(id=event_fixture['id']))
+	assert delete_rv.status_code == 204
+	event_result = _get_event_fixture(client, event_fixture['id'])
+	assert event_result is None

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2,6 +2,8 @@ import pytest
 
 from context import app # check sys.path if this fails
 
+non_existent_id='007404007' # does not match an resource, reliably gives a 404
+
 @pytest.fixture
 def client():
 	app.app.config['TESTING'] = True
@@ -67,6 +69,11 @@ def test_get_event(client):
 	assert 'id' in event_result and event_result['id'] == event_fixture['id']
 	assert 'title' in event_result and event_result['title'] == event_fixture['title']
 
+def test_get_event_not_found(client):
+	"""Test GET /events/{id} API with a non-existent {id}"""
+	get_rv = client.get('/api/events/{id}'.format(id=non_existent_id))
+	assert get_rv.status_code == 404
+
 def test_put_event(client):
 	"""Test PUT /events/{id} API for event modification"""
 	event_fixture = _post_event_fixture(client, 'PUT Event Test')
@@ -77,6 +84,11 @@ def test_put_event(client):
 	event_result = _get_event_fixture(client, event_fixture['id'])
 	assert 'title' in event_result and event_result['title'] == event_fixture['title']
 
+def test_put_event_not_found(client):
+	"""Test PUT /events/{id} API with a non-existent {id}"""
+	put_rv = client.put('/api/events/{id}'.format(id=non_existent_id), json={})
+	assert put_rv.status_code == 404
+
 def test_delete_event(client):
 	"""Test DELETE /events/{id} API for event deletion"""
 	event_fixture = _post_event_fixture(client, 'DELETE Event Test')
@@ -85,3 +97,8 @@ def test_delete_event(client):
 	assert delete_rv.status_code == 204
 	event_result = _get_event_fixture(client, event_fixture['id'])
 	assert event_result is None
+
+def test_delete_event_not_found(client):
+	"""Test DELETE /events/{id} API with a non-existent {id}"""
+	delete_rv = client.delete('/api/events/{id}'.format(id=non_existent_id))
+	assert delete_rv.status_code == 404


### PR DESCRIPTION
All `/events` APIs are now operational (but transient - no data persistence, and minimal - `title`, `id` attributes only)