### PR TITLE
Event url

### DIFF
--- a/apps/api/endpoints/events.py
+++ b/apps/api/endpoints/events.py
@@ -8,7 +8,8 @@ ns = api.namespace('events', description='Operations related to scheduled events
 an_event = api.model('Event', {
 	'id': fields.Integer(description='The unique identifier of an event (internal)', readonly=True),
 	'title': fields.String(required=True, description='The name of the event as promoted publically', example='The John Beggs Memorial'),
-	'date': fields.Date(description='When will the event take place? ISO 8601 format: YYYY-MM-DD', example='2018-08-11')
+	'date': fields.Date(description='When will the event take place? ISO 8601 format: YYYY-MM-DD', example='2018-08-11'),
+	'url': fields.Url(description='The primary URL promoting the event', example='http://www.banbridgecc.com/thebeggs18/')
 	})
 
 events = []

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -60,7 +60,11 @@ def test_get_events_not_empty(client):
 
 def test_post_events(client):
 	'''Test POST /events API for event creation'''
-	event_fixture = {'title': 'The John Beggs', 'date': '2018-08-11'}
+	event_fixture = {
+		'title': 'The John Beggs',
+		'date': '2018-08-11',
+		'url': 'https://goo.gl/tVymnx'
+	}
 
 	post_rv = client.post('/api/events/', json=event_fixture)
 	assert post_rv.status_code == 201
@@ -87,6 +91,16 @@ def test_post_events_invalid_date(client):
 	assert post_rv.status_code == 400
 
 	event_fixture['date'] = '11-08-2018' # close but no cigar
+	post_rv = client.post('/api/events/', json=event_fixture)
+	assert post_rv.status_code == 400
+
+def test_post_events_invalid_url(client):
+	'''Test POST /events API for event creation when url field is not valid URL format'''
+	event_fixture = {'title': 'Invalid URL Event', 'url': 'foo bar'}
+	post_rv = client.post('/api/events/', json=event_fixture)
+	assert post_rv.status_code == 400
+
+	event_fixture['url'] = 'goo.gl/tVymnx' # close but no cigar
 	post_rv = client.post('/api/events/', json=event_fixture)
 	assert post_rv.status_code == 400
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -94,16 +94,6 @@ def test_post_events_invalid_date(client):
 	post_rv = client.post('/api/events/', json=event_fixture)
 	assert post_rv.status_code == 400
 
-def test_post_events_invalid_url(client):
-	'''Test POST /events API for event creation when url field is not valid URL format'''
-	event_fixture = {'title': 'Invalid URL Event', 'url': 'foo bar'}
-	post_rv = client.post('/api/events/', json=event_fixture)
-	assert post_rv.status_code == 400
-
-	event_fixture['url'] = 'goo.gl/tVymnx' # close but no cigar
-	post_rv = client.post('/api/events/', json=event_fixture)
-	assert post_rv.status_code == 400
-
 def test_get_event(client):
 	"""Test GET /events/{id} API"""
 	event_fixture = _post_event_fixture(client, 'GET Event Test')


### PR DESCRIPTION
Closes #25 
URL validation not implemented. Why doesn't it "just work" with `fields.Url` and `@api.expect(validate=True)`?