### PR TITLE
Fix event URL field model

### DIFF
--- a/apps/api/endpoints/events.py
+++ b/apps/api/endpoints/events.py
@@ -9,7 +9,7 @@ an_event = api.model('Event', {
 	'id': fields.Integer(description='The unique identifier of an event (internal)', readonly=True),
 	'title': fields.String(required=True, description='The name of the event as promoted publically', example='The John Beggs Memorial'),
 	'date': fields.Date(description='When will the event take place? ISO 8601 format: YYYY-MM-DD', example='2018-08-11'),
-	'url': fields.Url(description='The primary URL promoting the event', example='http://www.banbridgecc.com/thebeggs18/')
+	'url': fields.String(description='The primary URL promoting the event', example='http://www.banbridgecc.com/thebeggs18/')
 	})
 
 events = []


### PR DESCRIPTION
`fields.Url` is for referencing server-side API resources
It can be used to include or reference other resources in your API's 
response
E.g. `'organising_club': fields.Url('clubs')`
For external URLs, use `fields.String` or implement a custom field with 
validation if desired.

From [the documentation](https://media.readthedocs.org/pdf/flask-restplus/stable/flask-restplus.pdf):
## 3.3.5 Url & Other Concrete Fields
Flask-RESTPlus includes a special field, fields.Url, that synthesizes a uri for the resource that’s being requested. This is also a good example of how to add data to your response that’s not actually present on your data object.