### PR TITLE
Event status

### DIFF
--- a/apps/api/logic.py
+++ b/apps/api/logic.py
@@ -44,6 +44,10 @@ class PeristentModel:
 		all_events = Result(db.all_docs, include_docs=True)
 		return [event for event in all_events]
 
+event_status = api.model('Status', {
+	'state': fields.String(description='Is the event still on?', enum=['scheduled', 'provisional', 'cancelled', 'completed'], default='scheduled', example='scheduled'),
+	'url': fields.String(description='The primary URL where notice of the most recent state change was posted', example='http://www.banbridgecc.com/eventcancellation/')
+})
 
 an_event = api.model('Event', {
 	'id': fields.Integer(description='The unique identifier of an event (internal)', readonly=True),
@@ -51,7 +55,8 @@ an_event = api.model('Event', {
 	'date': fields.Date(required=True,description='When will the event take place? ISO 8601 format: YYYY-MM-DD', example='2018-08-11'),
 	'url': fields.String(description='The primary URL promoting the event', example='http://www.banbridgecc.com/thebeggs18/'),
 	'location': fields.String(description='The address of the event. Should identify at least the town.', example='Donore, Co. Down'),
-	'type': fields.String(required=True,description='The type of event. Is a road race, time trial, etc?', enum=['road race', 'time trial', 'hill climb', 'criterium', 'stage race'], default='road race', example='road race')
+	'type': fields.String(required=True,description='The type of event. Is a road race, time trial, etc?', enum=['road race', 'time trial', 'hill climb', 'criterium', 'stage race'], default='road race', example='road race'),
+	'status': fields.Nested(event_status, description='Records any schedule changes. If absent assume event is still scheduled normally')
 	})
 
 data_store = TransientModel()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -189,11 +189,10 @@ def test_delete_event_not_found(client):
 def test_put_event_status(client):
 	"""Test PUT /events/{id} API for event status modification"""
 	event_fixture = _post_event_fixture(client, 'PUT Event Status Test')
-	assert status in event_fixture # test has default status
-	assert event_fixture['status']['state'] == 'scheduled' # test default state value
+	assert 'status' not in event_fixture # test has default status
 
-	event_fixture['status']['state'] = 'cancelled'
-	event_fixture['status']['url'] = 'http://sorryaboutthat.com/notice'
+	event_status_fixture = {'state': 'cancelled', 'url': 'http://sorryaboutthat.com/notice'}
+	event_fixture['status'] = event_status_fixture
 	put_rv = client.put('/api/events/{id}'.format(id=event_fixture['id']), json=event_fixture)
 	assert put_rv.status_code == 204
 	event_result = _get_event_fixture(client, event_fixture['id'])


### PR DESCRIPTION
Closes #32 

Events can be created without a `status` object, in which case clients should assume them to be scheduled normally with no exceptional scheduling changes having been recorded.

If an exceptional scheduling change is recorded, such as a cancellation, the state change and the notice URL are captured in the `status` object.